### PR TITLE
Add FR-04 contract and integration regression tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,6 +249,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1086,6 +1096,15 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "command-fds"
@@ -2780,6 +2799,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2793,6 +2818,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -3655,6 +3681,31 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "mockito"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90820618712cab19cfc46b274c6c22546a82affcb3c3bdf0f29e3db8e1bb92c0"
+dependencies = [
+ "assert-json-diff",
+ "bytes",
+ "colored",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "pin-project-lite",
+ "rand 0.9.2",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
 ]
 
 [[package]]
@@ -5482,6 +5533,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "simplecss"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5571,6 +5628,7 @@ dependencies = [
  "gpui-component",
  "jsonschema",
  "libc",
+ "mockito",
  "reqwest",
  "serde",
  "serde_json",
@@ -6149,6 +6207,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,6 @@ thiserror = "2.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = "0.25.0"
+
+[dev-dependencies]
+mockito = "1.6"

--- a/tests/fr04_generation_engine.rs
+++ b/tests/fr04_generation_engine.rs
@@ -1,0 +1,476 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::thread;
+use std::time::Duration;
+
+use mockito::{Matcher, Server};
+use serde_json::json;
+use sonant::app::{GenerationRetryConfig, GenerationService};
+use sonant::domain::{
+    GeneratedNote, GenerationCandidate, GenerationMetadata, GenerationMode, GenerationParams,
+    GenerationRequest, GenerationResult, GenerationUsage, LlmError, ModelRef,
+};
+use sonant::infra::llm::schema_validator::LlmResponseSchemaValidator;
+use sonant::infra::llm::{
+    AnthropicProvider, LlmProvider, OpenAiCompatibleProvider, ProviderRegistry,
+};
+
+fn valid_request(provider: &str, model: &str) -> GenerationRequest {
+    GenerationRequest {
+        request_id: "req-1".to_string(),
+        model: ModelRef {
+            provider: provider.to_string(),
+            model: model.to_string(),
+        },
+        mode: GenerationMode::Melody,
+        prompt: "warm synth melody".to_string(),
+        params: GenerationParams {
+            bpm: 120,
+            key: "C".to_string(),
+            scale: "major".to_string(),
+            density: 3,
+            complexity: 3,
+            temperature: Some(0.7),
+            top_p: Some(0.9),
+            max_tokens: Some(512),
+        },
+        references: Vec::new(),
+        variation_count: 1,
+    }
+}
+
+fn valid_result(request: &GenerationRequest) -> GenerationResult {
+    GenerationResult {
+        request_id: request.request_id.clone(),
+        model: request.model.clone(),
+        candidates: vec![GenerationCandidate {
+            id: "cand-1".to_string(),
+            bars: 4,
+            notes: vec![GeneratedNote {
+                pitch: 60,
+                start_tick: 0,
+                duration_tick: 240,
+                velocity: 96,
+                channel: 1,
+            }],
+            score_hint: Some(0.8),
+        }],
+        metadata: GenerationMetadata::default(),
+    }
+}
+
+fn generation_result_json(provider: &str, model: &str, request_id: &str) -> String {
+    json!({
+        "request_id": request_id,
+        "model": {
+            "provider": provider,
+            "model": model
+        },
+        "candidates": [
+            {
+                "id": "cand-1",
+                "bars": 4,
+                "notes": [
+                    {
+                        "pitch": 60,
+                        "start_tick": 0,
+                        "duration_tick": 240,
+                        "velocity": 96,
+                        "channel": 1
+                    }
+                ]
+            }
+        ]
+    })
+    .to_string()
+}
+
+struct DummyProvider {
+    provider_id: &'static str,
+    model_id: &'static str,
+}
+
+impl LlmProvider for DummyProvider {
+    fn provider_id(&self) -> &str {
+        self.provider_id
+    }
+
+    fn supports_model(&self, model_id: &str) -> bool {
+        model_id == self.model_id
+    }
+
+    fn generate(&self, request: &GenerationRequest) -> Result<GenerationResult, LlmError> {
+        Ok(valid_result(request))
+    }
+}
+
+struct FlakyProvider {
+    calls: Arc<AtomicUsize>,
+    failures_before_success: usize,
+}
+
+impl LlmProvider for FlakyProvider {
+    fn provider_id(&self) -> &str {
+        "anthropic"
+    }
+
+    fn supports_model(&self, model_id: &str) -> bool {
+        model_id == "claude-3-5-sonnet"
+    }
+
+    fn generate(&self, request: &GenerationRequest) -> Result<GenerationResult, LlmError> {
+        let attempt = self.calls.fetch_add(1, Ordering::SeqCst) + 1;
+        if attempt <= self.failures_before_success {
+            return Err(LlmError::Timeout);
+        }
+        Ok(valid_result(request))
+    }
+}
+
+struct AlwaysTimeoutProvider {
+    calls: Arc<AtomicUsize>,
+}
+
+impl LlmProvider for AlwaysTimeoutProvider {
+    fn provider_id(&self) -> &str {
+        "anthropic"
+    }
+
+    fn supports_model(&self, model_id: &str) -> bool {
+        model_id == "claude-3-5-sonnet"
+    }
+
+    fn generate(&self, _request: &GenerationRequest) -> Result<GenerationResult, LlmError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Err(LlmError::Timeout)
+    }
+}
+
+#[test]
+fn schema_contract_accepts_valid_generation_result_payload() {
+    let validator = LlmResponseSchemaValidator::new().expect("schema should compile");
+
+    let result = validator
+        .validate_response_json(&generation_result_json(
+            "anthropic",
+            "claude-3-5-sonnet",
+            "req-1",
+        ))
+        .expect("valid payload should satisfy schema contract");
+
+    assert_eq!(result.request_id, "req-1");
+    assert_eq!(result.candidates.len(), 1);
+}
+
+#[test]
+fn schema_contract_rejects_unknown_top_level_property() {
+    let validator = LlmResponseSchemaValidator::new().expect("schema should compile");
+    let payload = json!({
+        "request_id": "req-1",
+        "model": {
+            "provider": "anthropic",
+            "model": "claude-3-5-sonnet"
+        },
+        "candidates": [
+            {
+                "id": "cand-1",
+                "bars": 4,
+                "notes": [
+                    {
+                        "pitch": 60,
+                        "start_tick": 0,
+                        "duration_tick": 240,
+                        "velocity": 96
+                    }
+                ]
+            }
+        ],
+        "unexpected": true
+    })
+    .to_string();
+
+    let error = validator
+        .validate_response_json(&payload)
+        .expect_err("additionalProperties=false should reject unknown fields");
+
+    assert!(matches!(error, LlmError::InvalidResponse { .. }));
+}
+
+#[test]
+fn provider_registry_resolves_registered_provider_for_model() {
+    let request = valid_request("anthropic", "claude-3-5-sonnet");
+    let mut registry = ProviderRegistry::new();
+    registry
+        .register(DummyProvider {
+            provider_id: "anthropic",
+            model_id: "claude-3-5-sonnet",
+        })
+        .expect("provider registration should succeed");
+
+    let provider = registry
+        .resolve("anthropic", "claude-3-5-sonnet")
+        .expect("provider should resolve");
+    let result = provider
+        .generate(&request)
+        .expect("resolved provider should generate");
+
+    assert_eq!(result.request_id, "req-1");
+}
+
+#[test]
+fn anthropic_generate_succeeds_through_http_mock() {
+    let mut server = Server::new();
+    let response_body = json!({
+        "id": "msg_01",
+        "stop_reason": "end_turn",
+        "usage": {
+            "input_tokens": 12,
+            "output_tokens": 8
+        },
+        "content": [
+            {
+                "type": "text",
+                "text": generation_result_json("anthropic", "claude-3-5-sonnet", "req-1")
+            }
+        ]
+    })
+    .to_string();
+
+    let mock = server
+        .mock("POST", "/v1/messages")
+        .match_header("x-api-key", "test-key")
+        .match_header("anthropic-version", "2023-06-01")
+        .match_header(
+            "content-type",
+            Matcher::Regex("application/json.*".to_string()),
+        )
+        .match_body(Matcher::Regex(
+            "\"model\"\\s*:\\s*\"claude-3-5-sonnet\"".to_string(),
+        ))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_header("request-id", "anthropic-req-1")
+        .with_body(response_body)
+        .create();
+
+    let provider = AnthropicProvider::with_config("test-key", server.url(), Duration::from_secs(2))
+        .expect("provider should build");
+    let request = valid_request("anthropic", "claude-3-5-sonnet");
+
+    let result = provider
+        .generate(&request)
+        .expect("mocked anthropic response should parse");
+
+    mock.assert();
+    assert_eq!(result.request_id, "req-1");
+    assert_eq!(result.metadata.stop_reason.as_deref(), Some("end_turn"));
+    assert_eq!(
+        result.metadata.provider_request_id.as_deref(),
+        Some("anthropic-req-1")
+    );
+    assert_eq!(
+        result.metadata.usage,
+        Some(GenerationUsage {
+            input_tokens: Some(12),
+            output_tokens: Some(8),
+            total_tokens: Some(20),
+            cache_creation_input_tokens: None,
+            cache_read_input_tokens: None,
+        })
+    );
+}
+
+#[test]
+fn anthropic_generate_maps_rate_limit_http_error() {
+    let mut server = Server::new();
+    let mock = server
+        .mock("POST", "/v1/messages")
+        .with_status(429)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"error":{"type":"rate_limit_error","message":"slow down"}}"#)
+        .create();
+
+    let provider = AnthropicProvider::with_config("test-key", server.url(), Duration::from_secs(2))
+        .expect("provider should build");
+    let request = valid_request("anthropic", "claude-3-5-sonnet");
+
+    let error = provider
+        .generate(&request)
+        .expect_err("429 should map to rate-limited error");
+
+    mock.assert();
+    assert!(matches!(error, LlmError::RateLimited));
+}
+
+#[test]
+fn openai_compatible_generate_succeeds_through_http_mock() {
+    let mut server = Server::new();
+    let response_body = json!({
+        "id": "chatcmpl_01",
+        "choices": [
+            {
+                "finish_reason": "stop",
+                "message": {
+                    "content": generation_result_json("openai_compatible", "gpt-5.2", "req-1")
+                }
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 30,
+            "completion_tokens": 11
+        }
+    })
+    .to_string();
+
+    let mock = server
+        .mock("POST", "/v1/chat/completions")
+        .match_header("authorization", "Bearer test-key")
+        .match_header(
+            "content-type",
+            Matcher::Regex("application/json.*".to_string()),
+        )
+        .match_body(Matcher::Regex("\"model\"\\s*:\\s*\"gpt-5.2\"".to_string()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_header("x-request-id", "openai-req-1")
+        .with_body(response_body)
+        .create();
+
+    let provider = OpenAiCompatibleProvider::with_config(
+        "openai_compatible",
+        "test-key",
+        server.url(),
+        Duration::from_secs(2),
+        vec!["gpt-5.2".to_string()],
+    )
+    .expect("provider should build");
+    let request = valid_request("openai_compatible", "gpt-5.2");
+
+    let result = provider
+        .generate(&request)
+        .expect("mocked openai-compatible response should parse");
+
+    mock.assert();
+    assert_eq!(result.request_id, "req-1");
+    assert_eq!(result.metadata.stop_reason.as_deref(), Some("stop"));
+    assert_eq!(
+        result.metadata.provider_request_id.as_deref(),
+        Some("openai-req-1")
+    );
+    assert_eq!(
+        result.metadata.usage,
+        Some(GenerationUsage {
+            input_tokens: Some(30),
+            output_tokens: Some(11),
+            total_tokens: Some(41),
+            cache_creation_input_tokens: None,
+            cache_read_input_tokens: None,
+        })
+    );
+}
+
+#[test]
+fn openai_compatible_generate_maps_timeout_http_error() {
+    let mut server = Server::new();
+    let mock = server
+        .mock("POST", "/v1/chat/completions")
+        .with_status(408)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"error":{"type":"server_timeout","code":"request_timeout","message":"timed out"}}"#,
+        )
+        .create();
+
+    let provider = OpenAiCompatibleProvider::with_config(
+        "openai_compatible",
+        "test-key",
+        server.url(),
+        Duration::from_secs(2),
+        vec!["gpt-5.2".to_string()],
+    )
+    .expect("provider should build");
+    let request = valid_request("openai_compatible", "gpt-5.2");
+
+    let error = provider
+        .generate(&request)
+        .expect_err("timeout status should map to timeout error");
+
+    mock.assert();
+    assert!(matches!(error, LlmError::Timeout));
+}
+
+#[test]
+fn generation_service_retries_retryable_errors_until_success() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let provider = Arc::new(FlakyProvider {
+        calls: Arc::clone(&calls),
+        failures_before_success: 2,
+    });
+
+    let mut registry = ProviderRegistry::new();
+    registry
+        .register_shared(provider)
+        .expect("provider registration should succeed");
+
+    let service = GenerationService::with_retry_config(
+        registry,
+        GenerationRetryConfig {
+            max_attempts: 3,
+            initial_backoff: Duration::from_millis(1),
+            max_backoff: Duration::from_millis(2),
+        },
+    )
+    .expect("retry config should be valid");
+
+    let result = service
+        .generate(valid_request("anthropic", "claude-3-5-sonnet"))
+        .expect("generation should succeed after retries");
+
+    assert_eq!(result.request_id, "req-1");
+    assert_eq!(calls.load(Ordering::SeqCst), 3);
+}
+
+#[test]
+fn generation_service_cancels_during_retry_backoff() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let provider = Arc::new(AlwaysTimeoutProvider {
+        calls: Arc::clone(&calls),
+    });
+
+    let mut registry = ProviderRegistry::new();
+    registry
+        .register_shared(provider)
+        .expect("provider registration should succeed");
+
+    let service = GenerationService::with_retry_config(
+        registry,
+        GenerationRetryConfig {
+            max_attempts: 5,
+            initial_backoff: Duration::from_millis(200),
+            max_backoff: Duration::from_millis(200),
+        },
+    )
+    .expect("retry config should be valid");
+
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let cancelled_for_thread = Arc::clone(&cancelled);
+    let control_thread = thread::spawn(move || {
+        thread::sleep(Duration::from_millis(20));
+        cancelled_for_thread.store(true, Ordering::SeqCst);
+    });
+
+    let error = service
+        .generate_with_cancel(valid_request("anthropic", "claude-3-5-sonnet"), || {
+            cancelled.load(Ordering::SeqCst)
+        })
+        .expect_err("cancel flag should stop retry backoff");
+
+    control_thread
+        .join()
+        .expect("control thread should join cleanly");
+    assert!(matches!(
+        error,
+        LlmError::Internal { message } if message == "generation cancelled"
+    ));
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+}


### PR DESCRIPTION
## Summary
- add a new FR-04 focused integration test suite under `tests/fr04_generation_engine.rs`
- verify JSON schema contract acceptance/rejection paths with `LlmResponseSchemaValidator`
- verify `ProviderRegistry` resolution behavior from a black-box integration test
- add HTTP-mock integration tests for both adapters:
  - `AnthropicProvider::generate` success path + 429 rate-limit mapping
  - `OpenAiCompatibleProvider::generate` success path + timeout error mapping
- add retry/cancellation regression tests via `GenerationService` to guard retryable error handling and cancellation during backoff
- add `mockito` as a dev dependency for HTTP mocking

## Verification
- `cargo fmt`
- `cargo test --test fr04_generation_engine`
- `cargo test`
- `cargo clippy --all-targets --all-features`

Closes #8
