### PR TITLE
FR-02: GPUIヘルパーに自然言語プロンプト入力を実装

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -381,10 +381,7 @@ impl Render for SonantMainWindow {
                                 "Generate"
                             })
                             .loading(generating)
-                            .disabled(matches!(
-                                self.generation_status,
-                                HelperGenerationStatus::Submitting { .. }
-                            ))
+                            .disabled(generating)
                             .on_click(cx.listener(|this, _, window, cx| {
                                 this.on_generate_clicked(window, cx)
                             })),


### PR DESCRIPTION
## 概要
- GPUIヘルパーをPoC画面からFR-02最小実装へ更新
- 複数行プロンプト入力（`gpui-component::InputState`）を追加し、Generate操作を`GenerationJobManager`へ接続
- 空文字/空白のみ入力を拒否し、UIにインラインでバリデーションエラーを表示
- `GenerationRequest.prompt`への反映経路を`PromptSubmissionModel` + `build_generation_request`で実装
- 送信前後の状態遷移（Idle/Submitting/Running/Succeeded/Failed/Cancelled）をUI表示へ反映
- Provider未設定時でも経路検証できるよう、ヘルパー専用stub providerフォールバックを追加

## 変更ファイル
- `src/main.rs`

## テスト
- `cargo fmt`
- `cargo test`
- `cargo clippy --all-targets --all-features`
- `cargo run -- --gpui-helper`（起動確認。3秒後にプロセス停止してログ確認）

## 関連
Closes #18
