### PR TITLE
Implement user-facing MIDI load error recovery flow

### DIFF
--- a/src/app/load_midi_use_case.rs
+++ b/src/app/load_midi_use_case.rs
@@ -446,6 +446,36 @@ mod tests {
         assert!(error.user_message().contains(".mid"));
     }
 
+    #[test]
+    fn user_message_for_corrupted_midi_is_actionable() {
+        let error = LoadMidiError::LoadFailed {
+            source: MidiLoadError::Parse {
+                message: "invalid smf".to_string(),
+            },
+        };
+
+        assert!(
+            error.user_message().contains("could not be parsed as MIDI"),
+            "expected parse error message to explain corruption"
+        );
+    }
+
+    #[test]
+    fn user_message_for_io_failure_suggests_recovery() {
+        let error = LoadMidiError::LoadFailed {
+            source: MidiLoadError::Io {
+                message: "permission denied".to_string(),
+            },
+        };
+
+        assert!(
+            error
+                .user_message()
+                .contains("Check the file path and permissions"),
+            "expected IO error message to suggest path/permission checks"
+        );
+    }
+
     fn sample_reference_data(
         bars: u16,
         note_count: u32,


### PR DESCRIPTION
## Summary
- Implements Issue #26 by improving user-facing handling for reference MIDI file load failures.
- Adds retry and reselect actions so users can recover quickly after a failed load.
- Expands error-message tests for representative failure cases.

## Key Changes
- Introduced structured MIDI slot error state in `src/main.rs` to carry message + retry eligibility + retry path.
- Added an inline error action area in the GPUI helper with:
  - `Retry` button (enabled for transient load failures like I/O/parse)
  - `Choose Another File` button for immediate re-selection
- Mapped non-retryable UI-side errors (invalid extension, drop/file-dialog issues) into the same display region.
- Added tests in `src/main.rs` to verify retry eligibility decisions.
- Added tests in `src/app/load_midi_use_case.rs` to ensure actionable user messages for:
  - non-MIDI extension
  - corrupted MIDI parse failure
  - file read I/O failure

## Verification
- `cargo fmt`
- `cargo clippy --all-targets --all-features`
- `cargo test`

All commands passed locally.

Closes #26
