### PR TITLE
Implement FR-03a regression tests for issue #27

### DIFF
--- a/tests/support/temp_file_fixture.rs
+++ b/tests/support/temp_file_fixture.rs
@@ -1,0 +1,42 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use midly::Smf;
+
+pub(crate) fn write_midi_file(prefix: &str, extension: &str, smf: &Smf<'_>) -> TestFile {
+    let mut bytes = Vec::new();
+    smf.write_std(&mut bytes)
+        .expect("test MIDI serialization must succeed");
+    write_bytes_file(prefix, extension, &bytes)
+}
+
+pub(crate) fn write_bytes_file(prefix: &str, extension: &str, bytes: &[u8]) -> TestFile {
+    static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+    let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock should be after UNIX_EPOCH")
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!("{prefix}-{nanos}-{id}.{extension}"));
+
+    fs::write(&path, bytes).expect("test fixture file must be writable");
+    TestFile { path }
+}
+
+pub(crate) struct TestFile {
+    path: PathBuf,
+}
+
+impl TestFile {
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TestFile {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}


### PR DESCRIPTION
## 概要
Issue #27 (FR-03a テスト強化) を実装しました。MIDIローダー異常系の不足ケースを補完し、ローダーと参照連携の統合テストを追加しています。

## 変更内容
- `src/infra/midi/loader.rs`
  - 単体テストを1件追加
  - ファイル不在時に `MidiLoadError::Io` を返すことを検証
- `tests/fr03a_reference_midi_flow.rs` (新規)
  - 参照MIDI読み込み後に `GenerationRequest.references` が正しく構築される統合テストを追加
  - 参照スロットの差し替え/クリア状態遷移が継続生成 (`GenerationMode::Continuation`) のバリデーション結果に反映される統合テストを追加

## 検証
- `cargo fmt`
- `cargo test`
  - `src/lib.rs` unit tests: 100 passed
  - `src/main.rs` unit tests: 18 passed
  - `tests/fr03a_reference_midi_flow.rs`: 2 passed
  - `tests/fr04_generation_engine.rs`: 9 passed

Closes #27
