### PR TITLE
生成モードセレクタ（7モード）を実装

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -176,16 +176,26 @@ mod tests {
         let mut model = PromptSubmissionModel::new(test_model());
 
         let first = model
-            .prepare_request("first prompt".to_string(), Vec::new())
+            .prepare_request(
+                GenerationMode::Melody,
+                "first prompt".to_string(),
+                Vec::new(),
+            )
             .expect("first prompt should be accepted");
         let second = model
-            .prepare_request("second prompt".to_string(), Vec::new())
+            .prepare_request(
+                GenerationMode::Bassline,
+                "second prompt".to_string(),
+                Vec::new(),
+            )
             .expect("second prompt should be accepted");
 
         assert_eq!(first.request_id, "gpui-helper-req-1");
         assert_eq!(second.request_id, "gpui-helper-req-2");
         assert_eq!(first.prompt, "first prompt");
         assert_eq!(second.prompt, "second prompt");
+        assert_eq!(first.mode, GenerationMode::Melody);
+        assert_eq!(second.mode, GenerationMode::Bassline);
     }
 
     #[test]
@@ -194,9 +204,14 @@ mod tests {
         let references = vec![test_reference("/tmp/reference.mid")];
 
         let request = model
-            .prepare_request("continue this".to_string(), references.clone())
+            .prepare_request(
+                GenerationMode::Continuation,
+                "continue this".to_string(),
+                references.clone(),
+            )
             .expect("request should be prepared");
 
+        assert_eq!(request.mode, GenerationMode::Continuation);
         assert_eq!(request.references, references);
     }
 

--- a/src/ui/request.rs
+++ b/src/ui/request.rs
@@ -23,6 +23,7 @@ impl PromptSubmissionModel {
 
     pub(super) fn prepare_request(
         &mut self,
+        mode: GenerationMode,
         prompt: String,
         references: Vec<MidiReferenceSummary>,
     ) -> Result<GenerationRequest, LlmError> {
@@ -34,7 +35,7 @@ impl PromptSubmissionModel {
         build_generation_request_with_prompt_validation(
             request_id,
             self.model.clone(),
-            GenerationMode::Melody,
+            mode,
             prompt,
             references,
         )


### PR DESCRIPTION
## 概要
Issue #37 の要件に沿って、GPUI Helperに7種類の生成モードセレクタを追加しました。

## 変更内容
- `SonantMainWindow` に選択中モード状態（初期値: `Melody`）を追加
- 7モード（Melody / Chord Progression / Drum Pattern / Bassline / Counter Melody / Harmony / Continuation）の選択UIを追加
- モード変更時に `cx.notify()` を呼び出して再描画を反映
- 選択中モードを `Selected: ...` 表示とボタンの `primary` スタイルで可視化
- Generate押下時に選択中モードを `PromptSubmissionModel::prepare_request()` に渡すよう変更
- UIテストを更新し、リクエストに選択モードが反映されることを検証

## 検証
- `cargo fmt`
- `cargo test`

Closes #37
