### PR TITLE
Add all-mode coverage for request mode wiring

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -199,6 +199,28 @@ mod tests {
     }
 
     #[test]
+    fn submission_model_preserves_all_generation_modes() {
+        let mut model = PromptSubmissionModel::new(test_model());
+        let modes = [
+            GenerationMode::Melody,
+            GenerationMode::ChordProgression,
+            GenerationMode::DrumPattern,
+            GenerationMode::Bassline,
+            GenerationMode::CounterMelody,
+            GenerationMode::Harmony,
+            GenerationMode::Continuation,
+        ];
+
+        for (index, mode) in modes.into_iter().enumerate() {
+            let request = model
+                .prepare_request(mode, format!("prompt-{index}"), Vec::new())
+                .expect("prompt should be accepted");
+
+            assert_eq!(request.mode, mode);
+        }
+    }
+
+    #[test]
     fn submission_model_injects_references_into_request() {
         let mut model = PromptSubmissionModel::new(test_model());
         let references = vec![test_reference("/tmp/reference.mid")];


### PR DESCRIPTION
## Summary
- add `submission_model_preserves_all_generation_modes` to verify all 7 `GenerationMode` variants are propagated into `GenerationRequest.mode`
- guard against regressions of the previous Melody-fixed behavior in request assembly

## Verification
- cargo fmt
- cargo test
- cargo clippy --all-targets --all-features

Closes #38
