### PR TITLE
[FR-03b] Add LiveCapture bridge from CLAP to app layer

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -5,7 +5,9 @@ mod load_midi_use_case;
 
 pub use generation_job_manager::{GenerationJobManager, GenerationJobState, GenerationJobUpdate};
 pub use generation_service::{GenerationRetryConfig, GenerationService};
-pub use live_midi_capture::{LiveInputEvent, LiveInputEventSource, LiveMidiCapture};
+pub use live_midi_capture::{
+    LiveInputEvent, LiveInputEventSource, LiveMidiCapture, LiveMidiCaptureConfigError,
+};
 pub use load_midi_use_case::{
     FileMidiReferenceLoader, LoadMidiCommand, LoadMidiError, LoadMidiOutcome, LoadMidiUseCase,
     MidiReferenceLoader,

--- a/src/plugin/clap_adapter/mod.rs
+++ b/src/plugin/clap_adapter/mod.rs
@@ -346,6 +346,7 @@ impl<'a> PluginAudioProcessor<'a, SonantShared, SonantPluginMainThread<'a>>
 mod tests {
     use super::*;
     use clack_plugin::events::event_types::{NoteOffEvent, NoteOnEvent};
+    use std::num::NonZeroUsize;
     use std::sync::Arc;
 
     #[test]
@@ -518,7 +519,10 @@ mod tests {
         shared.flush_live_input_to_app();
 
         let source: Arc<dyn crate::app::LiveInputEventSource> = shared.clone();
-        let capture = crate::app::LiveMidiCapture::with_capacity(source, 8);
+        let capture = crate::app::LiveMidiCapture::with_capacity(
+            source,
+            NonZeroUsize::new(8).expect("test capacity must be non-zero"),
+        );
 
         assert_eq!(capture.ingest_available(), 1);
         assert_eq!(


### PR DESCRIPTION
## Summary
- add `app::live_midi_capture` with `LiveInputEvent`, `LiveInputEventSource`, and `LiveMidiCapture`
- bridge `plugin::clap_adapter::SonantShared` into the app-layer capture path via `LiveInputEventSource`
- add tests for non-blocking ingest/poll behavior and CLAP->App live-input integration

## Verification
- cargo fmt
- cargo clippy --all-targets --all-features
- cargo test

Closes #59
