### PR TITLE
Align theme color palette with reference design

### DIFF
--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -2,7 +2,6 @@ use gpui::{App, Global, Hsla, Pixels, SharedString, px, rgb};
 use gpui_component::Theme;
 
 #[derive(Debug, Clone, Copy)]
-#[allow(dead_code)]
 pub(super) struct ThemeColors {
     pub(super) surface_background: Hsla,
     pub(super) surface_foreground: Hsla,
@@ -21,18 +20,31 @@ pub(super) struct ThemeColors {
     pub(super) progress_foreground: Hsla,
     pub(super) drop_invalid_border: Hsla,
     pub(super) drop_invalid_background: Hsla,
+    #[allow(dead_code)]
     pub(super) track_purple: Hsla,
+    #[allow(dead_code)]
     pub(super) track_blue: Hsla,
+    #[allow(dead_code)]
     pub(super) track_green: Hsla,
+    #[allow(dead_code)]
     pub(super) track_red: Hsla,
+    #[allow(dead_code)]
     pub(super) track_orange: Hsla,
+    #[allow(dead_code)]
     pub(super) track_cyan: Hsla,
+    #[allow(dead_code)]
     pub(super) glow_primary: Hsla,
+    #[allow(dead_code)]
     pub(super) glow_purple: Hsla,
+    #[allow(dead_code)]
     pub(super) glow_blue: Hsla,
+    #[allow(dead_code)]
     pub(super) glow_green: Hsla,
+    #[allow(dead_code)]
     pub(super) glow_red: Hsla,
+    #[allow(dead_code)]
     pub(super) glow_orange: Hsla,
+    #[allow(dead_code)]
     pub(super) glow_cyan: Hsla,
 }
 


### PR DESCRIPTION
## Summary

カラーパレットをリファレンスデザイン (`docs/image/sonant_main_plugin_interface/code.html`) と整合させ、トラックカラー・グローシャドウ色・primaryカラーを `ThemeColors` に追加。

## Changes

### カラーパレット整合
| Field | Before | After (Reference) |
|-------|--------|-------------------|
| `surface_background` | `#111827` | `#101322` (background-dark) |
| `panel_background` | `#0f172a` | `#161b2e` (panel-dark) |
| `panel_border` | `#334155` | `#2a3254` (border-dark) |
| `panel_active_border` | `#67e8f9` | `#1032e2` (primary) |

### 新規フィールド
- **`input_background`**: `#1d233b` (input-dark)
- **`primary`** / **`primary_dark`**: `#1032e2` / `#0b24a8`
- **Track colors**: `track_purple`, `track_blue`, `track_green`, `track_red`, `track_orange`, `track_cyan`
- **Glow shadow colors**: `glow_primary`, `glow_purple`, `glow_blue`, `glow_green`, `glow_red`, `glow_orange`, `glow_cyan`

### gpui_component テーママッピング更新
- `component_theme.primary` が `panel_active_border` の代用から専用の `primary` フィールドを使用するように変更
- `component_theme.ring` も同様に `primary` を使用

## Testing
- `cargo test`: 209 tests passed
- `cargo clippy --all-targets --all-features`: no warnings

Closes #85