### PR TITLE
Align window size and sidebar width to reference design

### DIFF
--- a/src/plugin/clap_adapter/gui_extension.rs
+++ b/src/plugin/clap_adapter/gui_extension.rs
@@ -60,8 +60,8 @@ impl PluginGuiImpl for SonantPluginMainThread<'_> {
 
     fn get_size(&mut self) -> Option<GuiSize> {
         Some(GuiSize {
-            width: 640,
-            height: 420,
+            width: 800,
+            height: 640,
         })
     }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -16,7 +16,7 @@ mod theme;
 mod utils;
 mod window;
 
-const HELPER_WINDOW_WIDTH: f32 = 700.0;
+const HELPER_WINDOW_WIDTH: f32 = 800.0;
 const HELPER_WINDOW_HEIGHT: f32 = 640.0;
 const PROMPT_EDITOR_HEIGHT_PX: f32 = 220.0;
 const PROMPT_EDITOR_ROWS: usize = 8;

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -1714,7 +1714,7 @@ impl Render for SonantMainWindow {
                     .child(
                         div()
                             .id("left-sidebar")
-                            .w(px(420.0))
+                            .w(px(320.0))
                             .flex_none()
                             .flex()
                             .flex_col()


### PR DESCRIPTION
## 概要

ウィンドウサイズとサイドバー幅をリファレンスデザインに合わせて調整しました。

## 変更内容

### 1. GPUI Helper Window (src/ui/mod.rs)
- `HELPER_WINDOW_WIDTH`: 700.0 → **800.0** pixels

### 2. CLAP Plugin Size (src/plugin/clap_adapter/gui_extension.rs)
- `get_size()`: 640x420 → **800x640** pixels

### 3. Left Sidebar Width (src/ui/window.rs)
- サイドバー幅: 420.0 → **320.0** pixels

## 新しいレイアウト寸法

| 要素 | サイズ | 比率 |
|------|--------|------|
| ウィンドウ全体 | 800 x 640 px | - |
| 左サイドバー | 320 px | 40% |
| 右コンテンツエリア | 480 px | 60% |

従来の280pxから480pxに拡大し、**+200px**のピアノロール表示領域を確保しました。

## リファレンスデザインとの整合性

- リファレンス画像: 1600x1280 pixels (2x Retina)
- 論理ピクセル: **800x640 pixels** ✅
- サイドバー: w-80 (Tailwind) = **320px** ✅

## テスト結果

```bash
cargo build    # ✅ 成功
cargo test     # ✅ 全151テスト合格
```

すべての統合テスト・ユニットテストが引き続き合格しています。

## 検証項目

- [x] GPUI HelperウィンドウとCLAP `get_size()` が一致
- [x] サイドバー幅がリファレンスに近い比率
- [x] `cargo build` 成功
- [x] `cargo test` 全テスト合格

## 関連Issue

Closes #86