### PR TITLE
Generated Patternsの各アイテムにGroove/Temperature/Seedスライダーを追加

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -28,6 +28,8 @@ const DEFAULT_TEMPERATURE: f32 = 0.7;
 const DEFAULT_TOP_P: f32 = 0.9;
 const DEFAULT_MAX_TOKENS: u16 = 512;
 const DEFAULT_VARIATION_COUNT: u8 = 1;
+const DEFAULT_GROOVE: f32 = 0.0;
+const DEFAULT_RANDOM_SEED: u32 = 0;
 
 const DEFAULT_ANTHROPIC_MODEL: &str = "claude-3-5-sonnet";
 const DEFAULT_OPENAI_COMPAT_MODEL: &str = "gpt-5.2";

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -1,4 +1,5 @@
 use super::theme::ThemeColors;
+use super::{DEFAULT_GROOVE, DEFAULT_RANDOM_SEED, DEFAULT_TEMPERATURE};
 use sonant::app::LoadMidiError;
 use sonant::domain::{GenerationMode, MidiReferenceSummary, ReferenceSlot};
 use sonant::infra::midi::MidiLoadError;
@@ -401,6 +402,23 @@ fn provider_status_from_draft(draft: &SettingsDraftState) -> ProviderStatus {
     }
 
     ProviderStatus::Connected
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct CandidateParams {
+    pub(super) groove: f32,
+    pub(super) temperature: f32,
+    pub(super) random_seed: u32,
+}
+
+impl Default for CandidateParams {
+    fn default() -> Self {
+        Self {
+            groove: DEFAULT_GROOVE,
+            temperature: DEFAULT_TEMPERATURE,
+            random_seed: DEFAULT_RANDOM_SEED,
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #97

## 変更内容

Generated Patterns一覧の各アイテムの下部に以下のオプションスライダーを追加しました。

- **Groove** (0.0〜1.0): スライダー入力、小数点1桁表示
- **Temperature** (0.0〜2.0): スライダー入力、小数点1桁表示
- **Seed** (0〜9999): スライダー入力、整数表示、ダイスボタン（⚄）でランダム値生成

## 実装詳細

- `src/ui/state.rs`: `CandidateParams` structを追加（groove, temperature, random_seedフィールド）
- `src/ui/mod.rs`: `DEFAULT_GROOVE`, `DEFAULT_RANDOM_SEED` 定数を追加
- `src/ui/window.rs`:
  - `gpui_component::slider` からSliderコンポーネントをimport
  - 候補ごとのスライダーEntityとサブスクリプションをフィールドとして保持
  - 生成成功時に `rebuild_candidate_sliders()` でスライダーを初期化
  - `on_candidate_randomize_seed()` でSeedをランダム生成
  - 候補アイテムの描画を縦方向構造に変更し、下部にスライダーセクションを追加
  - スクロールコンテナ高さを128px→224pxに拡大