### PR TITLE
Add piano roll playhead and generated note rendering (#95)

### DIFF
--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -8,6 +8,7 @@ pub(super) struct ThemeColors {
     pub(super) surface_foreground: Hsla,
     pub(super) panel_background: Hsla,
     pub(super) piano_roll_grid_line: Hsla,
+    pub(super) piano_roll_playhead: Hsla,
     pub(super) input_background: Hsla,
     pub(super) panel_border: Hsla,
     pub(super) panel_active_background: Hsla,
@@ -42,6 +43,9 @@ pub(super) struct ThemeColors {
     pub(super) glow_orange: Hsla,
     #[allow(dead_code)]
     pub(super) glow_cyan: Hsla,
+    #[allow(dead_code)]
+    pub(super) glow_pink: Hsla,
+    pub(super) glow_playhead: Hsla,
 }
 
 impl ThemeColors {
@@ -116,6 +120,7 @@ impl Default for SonantTheme {
                 surface_foreground: rgb(0xf9fafb).into(),
                 panel_background: rgb(0x161b2e).into(),
                 piano_roll_grid_line: rgb(0x1d233b).into(),
+                piano_roll_playhead: rgb(0xeab308).into(),
                 input_background: rgb(0x1d233b).into(),
                 panel_border: rgb(0x2a3254).into(),
                 panel_active_background: rgb(0x1d233b).into(),
@@ -144,6 +149,8 @@ impl Default for SonantTheme {
                 glow_red: rgb(0xef4444).into(),
                 glow_orange: rgb(0xf97316).into(),
                 glow_cyan: rgb(0x06b6d4).into(),
+                glow_pink: rgb(0xec4899).into(),
+                glow_playhead: rgb(0xeab308).into(),
             },
             typography: ThemeTypography {
                 font_family: ".SystemUIFont".into(),

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -1266,6 +1266,10 @@ impl SonantMainWindow {
                                     .flex_1()
                                     .track_scroll(vertical_scroll_handle)
                                     .overflow_y_scroll()
+                                    .map(|mut this| {
+                                        this.style().restrict_scroll_to_axis = Some(true);
+                                        this
+                                    })
                                     .child(
                                         div()
                                             .id("piano-roll-key-label-canvas")
@@ -1309,6 +1313,10 @@ impl SonantMainWindow {
                             .relative()
                             .track_scroll(horizontal_scroll_handle)
                             .overflow_x_scroll()
+                            .map(|mut this| {
+                                this.style().restrict_scroll_to_axis = Some(true);
+                                this
+                            })
                             .scrollbar_width(px(8.0))
                             .horizontal_scrollbar(horizontal_scroll_handle)
                             .child(
@@ -1372,6 +1380,10 @@ impl SonantMainWindow {
                                             .relative()
                                             .track_scroll(vertical_scroll_handle)
                                             .overflow_y_scroll()
+                                            .map(|mut this| {
+                                                this.style().restrict_scroll_to_axis = Some(true);
+                                                this
+                                            })
                                             .scrollbar_width(px(8.0))
                                             .vertical_scrollbar(vertical_scroll_handle)
                                             .child(

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -1265,7 +1265,7 @@ impl SonantMainWindow {
                                     .id("piano-roll-key-label-viewport")
                                     .flex_1()
                                     .track_scroll(vertical_scroll_handle)
-                                    .overflow_scroll()
+                                    .overflow_y_scroll()
                                     .child(
                                         div()
                                             .id("piano-roll-key-label-canvas")
@@ -1306,8 +1306,9 @@ impl SonantMainWindow {
                             .id("piano-roll-main-grid-scroll")
                             .flex_1()
                             .h_full()
+                            .relative()
                             .track_scroll(horizontal_scroll_handle)
-                            .overflow_scroll()
+                            .overflow_x_scroll()
                             .scrollbar_width(px(8.0))
                             .horizontal_scrollbar(horizontal_scroll_handle)
                             .child(
@@ -1368,8 +1369,9 @@ impl SonantMainWindow {
                                         div()
                                             .id("piano-roll-beat-grid-viewport")
                                             .flex_1()
+                                            .relative()
                                             .track_scroll(vertical_scroll_handle)
-                                            .overflow_scroll()
+                                            .overflow_y_scroll()
                                             .scrollbar_width(px(8.0))
                                             .vertical_scrollbar(vertical_scroll_handle)
                                             .child(


### PR DESCRIPTION
## 概要
- ピアノロール上部に `1.1` 形式のビート/小節ラベルを追加
- `live_capture_playhead_ppq` に連動する黄色のプレイヘッドラインと上部三角マーカーを追加
- `GenerationResult.candidates` のノートをピアノロールに投影する描画ロジックを追加
- 選択候補はトラック色（#90 の `ReferenceSlot` カラー）で描画し、非選択候補はゴースト（薄い塗り + dashed border）で描画
- ピアノロール描画ヘルパーのユニットテストを追加
- テーマにプレイヘッド色/グロー色を追加

## 変更ファイル
- `src/ui/window.rs`
- `src/ui/theme.rs`

## 動作確認
- `cargo fmt`
- `cargo test`

## Issue
Closes #95
